### PR TITLE
Unicode support into static-generator

### DIFF
--- a/gemtextRender/gemtextRender.go
+++ b/gemtextRender/gemtextRender.go
@@ -67,6 +67,14 @@ func (g *GemtextRender) peekNextToken() (markdownLexer.Token, error) {
 	return g.tokenStream[g.idx+1], nil
 }
 
+func (g *GemtextRender) hasPrevToken () bool {
+	return g.idx > 0
+}
+
+func (g *GemtextRender) getPrevTokenType() markdownLexer.Token {
+	return g.tokenStream[g.idx-1];
+}
+
 func (g *GemtextRender) resetTokenRenderForLinks(old_idx int) string {
 	g.idx = old_idx
 	return g.tokenStream[g.idx].Literal
@@ -76,6 +84,7 @@ func (g *GemtextRender) resetTokenRenderForLinks(old_idx int) string {
 /* or different forms of links that can exist from markdown tokens */
 func (g *GemtextRender) renderLeftBracket() string {
 	old_idx := g.idx
+	var isLink bool = false
 
 	var str string
 	var link string
@@ -109,11 +118,13 @@ func (g *GemtextRender) renderLeftBracket() string {
 						switch token.Type {
 						case markdownLexer.RIGHT_PAREN:
 							str = "=> " + link + " " + desc + "\n"
+							isLink = true
 						default:
 							str = g.resetTokenRenderForLinks(old_idx)
 						}
 					case markdownLexer.RIGHT_PAREN:
 						str = "=> " + link + "\n"
+						isLink = true
 					default:
 						str = g.resetTokenRenderForLinks(old_idx)
 					}
@@ -128,6 +139,12 @@ func (g *GemtextRender) renderLeftBracket() string {
 		}
 	default:
 		str = g.resetTokenRenderForLinks(old_idx)
+	}
+
+	if isLink {
+		if g.tokenStream[old_idx - 1].Type != markdownLexer.NEW_LINE {
+			str = "\n" + str
+		}
 	}
 
 	return str

--- a/gemtextRender/gemtextRender.go
+++ b/gemtextRender/gemtextRender.go
@@ -154,6 +154,8 @@ func (g *GemtextRender) renderBulletMinus () string {
 	if g.hasPrevToken() {
 		if g.tokenStream[g.idx-1].Type == markdownLexer.NEW_LINE {
 			return "*"
+		} else {
+			return "-"
 		}
 	}
 	return "-"

--- a/gemtextRender/gemtextRender.go
+++ b/gemtextRender/gemtextRender.go
@@ -150,6 +150,15 @@ func (g *GemtextRender) renderLeftBracket() string {
 	return str
 }
 
+func (g *GemtextRender) renderBulletMinus () string {
+	if g.hasPrevToken() {
+		if g.tokenStream[g.idx-1].Type == markdownLexer.NEW_LINE {
+			return "*"
+		}
+	}
+	return "-"
+}
+
 /* Takes a token and renders that token to gemtext */
 func (g *GemtextRender) renderMdTokenToGemtext(t markdownLexer.Token) string {
 	var str string
@@ -165,7 +174,7 @@ func (g *GemtextRender) renderMdTokenToGemtext(t markdownLexer.Token) string {
 	case markdownLexer.CODE_BLOCK:
 		str = t.Literal
 	case markdownLexer.BULLET_MINUS:
-		str = "*"
+		str = g.renderBulletMinus()
 	case markdownLexer.BULLET_PLUS:
 		str = "*"
 	case markdownLexer.UNCHECKED:

--- a/gemtextRender/gemtextRender.go
+++ b/gemtextRender/gemtextRender.go
@@ -141,7 +141,7 @@ func (g *GemtextRender) renderLeftBracket() string {
 		str = g.resetTokenRenderForLinks(old_idx)
 	}
 
-	if isLink {
+	if isLink && old_idx > 0 {
 		if g.tokenStream[old_idx - 1].Type != markdownLexer.NEW_LINE {
 			str = "\n" + str
 		}

--- a/gemtextRender/gemtextRender.go
+++ b/gemtextRender/gemtextRender.go
@@ -108,12 +108,12 @@ func (g *GemtextRender) renderLeftBracket() string {
 						g.incrementIndex()
 						switch token.Type {
 						case markdownLexer.RIGHT_PAREN:
-							str = "=> " + link + " " + desc
+							str = "=> " + link + " " + desc + "\n"
 						default:
 							str = g.resetTokenRenderForLinks(old_idx)
 						}
 					case markdownLexer.RIGHT_PAREN:
-						str = "=> " + link
+						str = "=> " + link + "\n"
 					default:
 						str = g.resetTokenRenderForLinks(old_idx)
 					}

--- a/gemtextRender/gemtextRender_test.go
+++ b/gemtextRender/gemtextRender_test.go
@@ -120,7 +120,7 @@ func TestLinkGeneration(t *testing.T) {
 	if err != nil {
 		t.Errorf("Issue with rendering tokens")
 	}
-	expected := "=> netbsd.org NetBSD Website"
+	expected := "=> netbsd.org NetBSD Website\n"
 	if result != expected {
 		t.Errorf("Issue with rendering a link")
 	}

--- a/gemtextRender/gemtextRender_test.go
+++ b/gemtextRender/gemtextRender_test.go
@@ -171,7 +171,6 @@ func TestSampleFile(t *testing.T) {
 	var g GemtextRender
 	g.InitializeGemtextRender(tokens)
 	result, err := g.RenderDocument()
-	//fmt.Println(result)
 
 	file_expected := "sample/expected.gmi"
 	expected, err := os.ReadFile(file_expected)
@@ -181,11 +180,6 @@ func TestSampleFile(t *testing.T) {
 
 	result_bytes := []byte(result)
 	expected_bytes := []byte(string(expected))
-
-	// if len(result_bytes) != len(expected_bytes) {
-	// 	t.Errorf("Size of output file does not match expected file")
-	// 	t.Errorf("Size result: %d, size expected: %d", len(result_bytes), len(expected_bytes))
-	// }
 
 	for i := 0; i < len(expected_bytes); i++ {
 		if result_bytes[i] != expected_bytes[i] {

--- a/gemtextRender/gemtextRender_test.go
+++ b/gemtextRender/gemtextRender_test.go
@@ -49,7 +49,7 @@ func TestRenderHeaderTokens(t *testing.T) {
 /* Test rendering gemtext bullet points from markdown tokens */
 func TestRenderBulletPoints(t *testing.T) {
 	var err error
-	str := "+ -"
+	str := "+\n-"
 	var l markdownLexer.Lexer
 	l.InitializeLexer(str)
 	var tokens []markdownLexer.Token
@@ -185,5 +185,31 @@ func TestSampleFile(t *testing.T) {
 		if result_bytes[i] != expected_bytes[i] {
 			t.Errorf("Non matching characters as index: %d. Expected: %c, Actual: %c", i, expected_bytes[i], result_bytes[i])
 		}
+	}
+}
+
+func TestRenderBulletMinus (t *testing.T) {
+	str := "string-with-dashes"
+	var l markdownLexer.Lexer
+	l.InitializeLexer(str)
+	var token markdownLexer.Token
+	var tokens []markdownLexer.Token
+	token = l.NextToken()
+	for token.Type != markdownLexer.EOF {
+		tokens = append(tokens, token)
+		token = l.NextToken()
+	}
+	var g GemtextRender
+	g.InitializeGemtextRender(tokens)
+	result, err := g.RenderDocument()
+	if err != nil {
+		t.Errorf("Issue with rendering document from test string")
+	}
+	expected := "string-with-dashes"
+	if len(tokens) != 5 {
+		t.Errorf("Read the inproper amount of tokens")
+	}
+	if expected != result {
+		t.Errorf("Expected and result do not match. Expected: %s, Result: %s", expected, result)
 	}
 }

--- a/gemtextRender/sample/expected.gmi
+++ b/gemtextRender/sample/expected.gmi
@@ -13,6 +13,7 @@ How about this question mark?
 How about, a sentence with commas?
 
 => http://google.com this is a link
+
 * another unordered list token
 
 italic

--- a/markdownLexer/lexer.go
+++ b/markdownLexer/lexer.go
@@ -132,25 +132,6 @@ func (l *Lexer) lexHeaderToken() Token {
 	return t
 }
 
-/* Lex the dash tokens as either bullet points or horizontal rules */
-func (l *Lexer) lexHorizontalRule() Token {
-	var t Token
-
-	str := l.getRepeatCharToken(l.ch)
-	if str == "-" {
-		t.Type = BULLET_MINUS
-		t.Literal = str
-	} else if str == "---" {
-		t.Type = HORIZONTAL_RULE
-		t.Literal = str
-	} else {
-		t.Type = INVALID
-		t.Literal = str
-	}
-
-	return t
-}
-
 /* check if the character is a letter between A and Z, upper and lower case */
 func isLetter(ch rune) bool {
 	return ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
@@ -283,6 +264,28 @@ func (l *Lexer) getNumberTokens() int {
 	return len(l.tokens)
 }
 
+func (l *Lexer) lexDash () Token {
+	pos := l.position
+	var r []rune
+	var t Token
+	for l.ch  == '-' {
+		l.readChar()
+	}
+	r = l.runes[pos:l.position]
+	if len(r) == 1 {
+		t.Type = BULLET_MINUS
+		t.Literal = string(r)
+	} else if len(r) > 3 {
+		t.Type = HORIZONTAL_RULE
+		t.Literal = string(r)
+	} else {
+		t.Type = INVALID
+		t.Literal = string(r)
+	}
+	return t
+
+}
+
 /* Read the the next token in input */
 func (l *Lexer) NextToken() Token {
 	var token Token
@@ -335,7 +338,7 @@ func (l *Lexer) NextToken() Token {
 		token.Type = EXCLAMATION
 		token.Literal = string(l.ch)
 	case '-':
-		token = l.lexHorizontalRule()
+		token = l.lexDash()
 		return token
 	case '+':
 		token.Type = BULLET_PLUS

--- a/markdownLexer/lexer.go
+++ b/markdownLexer/lexer.go
@@ -172,13 +172,13 @@ func isContentWhiteSpace(ch rune) bool {
 
 func (l *Lexer) readContent() string {
 	pos := l.position
-	for isLetter(l.ch) || isDigit(l.ch) || isPunctuation(l.ch) || isContentWhiteSpace(l.ch) {
+	for isToken(l.ch) == false {
 		l.readChar()
 	}
 	return l.input[pos:l.position]
 }
 
-func isToken(ch byte) bool {
+func isToken(ch rune) bool {
 	switch ch {
 	case '#':
 		return true
@@ -193,8 +193,6 @@ func isToken(ch byte) bool {
 	case ')':
 		return true
 	case '`':
-		return true
-	case '!':
 		return true
 	case '-':
 		return true

--- a/markdownLexer/lexer.go
+++ b/markdownLexer/lexer.go
@@ -4,7 +4,8 @@ type Lexer struct {
 	input        string
 	position     int // current position in input
 	readPosition int // next position in input
-	ch           byte
+	runes        []rune
+	ch           rune
 	tokens       []Token
 }
 
@@ -16,9 +17,10 @@ func (l *Lexer) GetTokens() []Token {
 /* Set the input of Lexer instance */
 func (l *Lexer) InitializeLexer(in string) {
 	l.input = in
+	l.runes = []rune(in)
 	l.position = 0
 	l.readPosition = 1
-	l.ch = l.input[l.position]
+	l.ch = l.runes[l.position]
 }
 
 /* Advances the position in input */
@@ -26,7 +28,7 @@ func (l *Lexer) readChar() {
 	if l.readPosition >= len(l.input) {
 		l.ch = 0
 	} else {
-		l.ch = l.input[l.readPosition]
+		l.ch = l.runes[l.readPosition]
 	}
 	l.position = l.readPosition
 	l.readPosition += 1
@@ -75,7 +77,7 @@ func (l *Lexer) lexEscapeToken(id byte) Token {
 }
 
 /* Used to get repeacted characters that may be a token */
-func (l *Lexer) getRepeatCharToken(ch byte) string {
+func (l *Lexer) getRepeatCharToken(ch rune) string {
 	pos := l.position
 	for l.ch == ch {
 		l.readChar()
@@ -150,21 +152,21 @@ func (l *Lexer) lexHorizontalRule() Token {
 }
 
 /* check if the character is a letter between A and Z, upper and lower case */
-func isLetter(ch byte) bool {
+func isLetter(ch rune) bool {
 	return ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
 }
 
 /* check if the digit is a ascii number between 0 and 9 */
-func isDigit(ch byte) bool {
+func isDigit(ch rune) bool {
 	return ch >= '0' && ch <= '9'
 }
 
 /* check for allowed punctuation in content block */
-func isPunctuation(ch byte) bool {
+func isPunctuation(ch rune) bool {
 	return ch == '.' || ch == ',' || ch == '_' || ch == ':' || ch == '/' || ch == '?' || ch == '!' || ch == '\'' || ch == '"'
 }
 
-func isContentWhiteSpace(ch byte) bool {
+func isContentWhiteSpace(ch rune) bool {
 	return ch == ' '
 }
 
@@ -315,7 +317,7 @@ func (l *Lexer) NextToken() Token {
 		token.Type = RIGHT_PAREN
 		token.Literal = string(l.ch)
 	case '`':
-		var c []byte
+		var c []rune
 		for l.ch == '`' {
 			c = append(c, l.ch)
 			l.readChar()

--- a/markdownLexer/lexer.go
+++ b/markdownLexer/lexer.go
@@ -153,14 +153,14 @@ func isContentWhiteSpace(ch rune) bool {
 
 func (l *Lexer) readContent() string {
 	pos := l.position
-	for isToken(l.ch) == false {
+	for l.isToken() == false {
 		l.readChar()
 	}
 	return l.input[pos:l.position]
 }
 
-func isToken(ch rune) bool {
-	switch ch {
+func (l *Lexer) isToken() bool {
+	switch l.ch {
 	case '#':
 		return true
 	case '*':

--- a/markdownLexer/lexer.go
+++ b/markdownLexer/lexer.go
@@ -25,7 +25,7 @@ func (l *Lexer) InitializeLexer(in string) {
 
 /* Advances the position in input */
 func (l *Lexer) readChar() {
-	if l.readPosition >= len(l.input) {
+	if l.readPosition >= len(l.runes) {
 		l.ch = 0
 	} else {
 		l.ch = l.runes[l.readPosition]
@@ -41,15 +41,15 @@ func (l *Lexer) skipWhiteSpace() {
 }
 
 /* Look ahead to the next character in the stream */
-func (l *Lexer) lookAheadNextChar() byte {
+func (l *Lexer) lookAheadNextChar() rune {
 	if l.readPosition >= len(l.input) {
 		return 0
 	}
-	return l.input[l.readPosition]
+	return l.runes[l.readPosition]
 }
 
 /* Lex the character being excaped from in token */
-func (l *Lexer) lexEscapeToken(id byte) Token {
+func (l *Lexer) lexEscapeToken(id rune) Token {
 	var t Token
 
 	switch id {
@@ -83,7 +83,7 @@ func (l *Lexer) getRepeatCharToken(ch rune) string {
 		l.readChar()
 	}
 
-	return l.input[pos:l.position]
+	return string(l.runes[pos:l.position])
 }
 
 /* Lex the type of emphasis toke */
@@ -133,30 +133,30 @@ func (l *Lexer) lexHeaderToken() Token {
 }
 
 /* check if the character is a letter between A and Z, upper and lower case */
-func isLetter(ch rune) bool {
-	return ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
+func (l *Lexer) isLetter() bool {
+	return l.ch >= 'A' && l.ch <= 'Z' ||l.ch >= 'a' && l.ch <= 'z' || l.ch >= 0x7E
 }
 
 /* check if the digit is a ascii number between 0 and 9 */
-func isDigit(ch rune) bool {
-	return ch >= '0' && ch <= '9'
+func (l *Lexer) isDigit() bool {
+	return l.ch >= '0' && l.ch <= '9'
 }
 
 /* check for allowed punctuation in content block */
-func isPunctuation(ch rune) bool {
-	return ch == '.' || ch == ',' || ch == '_' || ch == ':' || ch == '/' || ch == '?' || ch == '!' || ch == '\'' || ch == '"'
+func (l *Lexer) isPunctuation() bool {
+	return l.ch == '.' || l.ch == ',' || l.ch == '_' || l.ch == ':' || l.ch == '/' || l.ch == '?' || l.ch == '!' || l.ch == '\'' || l.ch == '"'
 }
 
-func isContentWhiteSpace(ch rune) bool {
-	return ch == ' '
+func (l *Lexer) isContentWhiteSpace() bool {
+	return l.ch == ' '
 }
 
 func (l *Lexer) readContent() string {
 	pos := l.position
-	for l.isToken() == false {
+	for l.isPunctuation() || l.isDigit() || l.isLetter() || l.isPunctuation() || l.isContentWhiteSpace() {
 		l.readChar()
 	}
-	return l.input[pos:l.position]
+	return string(l.runes[pos:l.position])
 }
 
 func (l *Lexer) isToken() bool {
@@ -296,7 +296,6 @@ func (l *Lexer) NextToken() Token {
 		return token
 	}
 
-	// TODO: finish implementing state machine lexer
 	switch l.ch {
 
 	case '#':

--- a/markdownLexer/lexer_test.go
+++ b/markdownLexer/lexer_test.go
@@ -23,11 +23,11 @@ func TestInitializerLexer(t *testing.T) {
 func TestReadChar(t *testing.T) {
 	l := new(Lexer)
 	l.InitializeLexer("hello")
-	if l.ch != byte(l.input[0]) {
+	if l.ch != rune(l.input[0]) {
 		t.Errorf("Improper Initialization")
 	}
 	l.readChar()
-	if l.ch != byte(l.input[1]) {
+	if l.ch != rune(l.input[1]) {
 		t.Errorf("Did no advance properly")
 	}
 }
@@ -37,7 +37,7 @@ func TestSkipWhiteSpace(t *testing.T) {
 	l := new(Lexer)
 	l.InitializeLexer(testString)
 	l.skipWhiteSpace()
-	if l.ch != byte(testString[1]) {
+	if l.ch != rune(testString[1]) {
 		t.Errorf("White space not skipped")
 	}
 }

--- a/markdownLexer/lexer_test.go
+++ b/markdownLexer/lexer_test.go
@@ -331,3 +331,26 @@ func TestContentWithPunctuation(t *testing.T) {
 		t.Errorf("The incorrect token type was generated")
 	}
 }
+
+/* test for unicode characters */
+func TestUnicodeCharacters(t *testing.T) {
+	str := "£YË"
+	var lex Lexer
+	lex.InitializeLexer(str)
+	var tokens []Token
+	var token Token
+	token = lex.NextToken()
+	for token.Type != EOF {
+		tokens = append(tokens, token)
+		token = lex.NextToken()
+	}
+	if len(tokens) != 1 {
+		t.Errorf("Did not read unicode content properly")
+	}
+	if tokens[0].Type != CONTENT {
+		t.Errorf("Did not type the token properly")
+	}
+	if tokens[0].Literal != "£YË" {
+		t.Errorf("Did not catpure the literal of token correctly")
+	}
+}

--- a/markdownLexer/lexer_test.go
+++ b/markdownLexer/lexer_test.go
@@ -163,6 +163,7 @@ func TestReadContent(t *testing.T) {
 		tokens = append(tokens, token)
 		token = l.NextToken()
 	}
+
 	if tokens[0].Type != CONTENT {
 		t.Errorf("Could not parse 'hello . world ' as content")
 	}


### PR DESCRIPTION
Since we seem to have a solid basis for handling unicode now and if anything else needs to get touched up, it will probably be clearing up edge cases, I think we can call this feature branch done and pull it into the static-generator branch, then into dev. From there, touch up any lexer and gemtext render issues in the static-generator branch along with working on the html render.